### PR TITLE
handle custom messaging between nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Returns the object containing all active nodes and their properties (including t
 Returns the current leader node from the cluster.
 #### resign()
 If called on the current leader node, will force it to resign as the leader. A new election will be held, which means the same node could be re-elected.
-#### send(<customEvent>, <extra data>)
+#### send(customEvent, extraData)
 Sends custom events to all other nodes
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ dem.on('removed', function(data) {
 dem.on('elected', function(data) {
   console.log('You have been elected leader!');
 });
+
+dem.on('ciao', function(data) {
+    console.log("ciao from %s", data.id, data.extra)
+});
+
+dem.send("ciao", { hello: "world"});
+
 ```
 
 ## API
@@ -63,6 +70,8 @@ Fired when a new leader is selected.
 Fired on the server that has become the new leader.
 #### resigned
 Fired on the server that has resigned as the leader.
+#### <custom/all other events>
+Fired on all the server except the one that "sent" the event.
 
 ## License
 Copyright (c) 2016 James Simpson and GoldFire Studios, Inc.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Fired when a new leader is selected.
 Fired on the server that has become the new leader.
 #### resigned
 Fired on the server that has resigned as the leader.
-#### <custom/all other events>
+#### custom/all other events
 Fired on all the server except the one that "sent" the event.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Returns the object containing all active nodes and their properties (including t
 Returns the current leader node from the cluster.
 #### resign()
 If called on the current leader node, will force it to resign as the leader. A new election will be held, which means the same node could be re-elected.
+#### send(<customEvent>, <extra data>)
+Sends custom events to all other nodes
 
 ### Events
 All events return the data/configuration of the affected node as their first parameter.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Returns the current leader node from the cluster.
 #### resign()
 If called on the current leader node, will force it to resign as the leader. A new election will be held, which means the same node could be re-elected.
 #### send(customEvent, extraData)
-Sends custom events to all other nodes
+Sends a custom event to all other nodes
 
 ### Events
 All events return the data/configuration of the affected node as their first parameter.

--- a/lib/democracy.js
+++ b/lib/democracy.js
@@ -136,6 +136,8 @@ Democracy.prototype.send = function(event, extra) {
     // to handle custom messaging between nodes
     if (extra) data.extra = extra;
   }
+  
+  data.source = self.options.source[0] + ":" + self.options.source[1];
 
   // Data must be sent as a Buffer over the UDP socket.
   var msg = new Buffer(JSON.stringify(data));

--- a/lib/democracy.js
+++ b/lib/democracy.js
@@ -362,6 +362,23 @@ Democracy.prototype.nodes = function() {
 };
 
 /**
+ * Get the count of current nodes, including this one.
+ * @return {Object} All nodes.
+ */
+Democracy.prototype.nodesCount = function() {
+
+  function countOf(nodes){
+    var count = 0;
+    Object.keys(nodes).forEach(function(key,index) {
+        if (nodes[key] != null) {
+            count ++;
+        }
+    });
+    return count;
+  }
+  var self = this;
+
+/**
  * Find our current fearless leader.
  * @return {Object} Current leader.
  */

--- a/lib/democracy.js
+++ b/lib/democracy.js
@@ -133,6 +133,8 @@ Democracy.prototype.send = function(event, extra) {
   } else {
     data.weight = self._weight;
     data.state = self._state;
+    // to handle custom messaging between nodes
+    if (extra) data.extra = extra;
   }
 
   // Data must be sent as a Buffer over the UDP socket.
@@ -242,6 +244,9 @@ Democracy.prototype.processEvent = function(msg) {
     }
 
     self.emit('leader', self._nodes[data.id]);
+  } else {
+    // to handle custom messaging between nodes
+    self.emit(data.event, data);
   }
 
   return self;


### PR DESCRIPTION
I added two lines of code that allow nodes to communicate with each other with custom events - the use case I'm working on is a distributed monitoring and remediation system in which all nodes monitor services but only one (the elected master) are allowed to execute remediation actions.
These two lines of code simply allow not-"election" related events to pass through the framework and reach the nodes. 
Are you interested in pulling it in the master branch and publishing it in npm (after having reviewed it, of course)?

Regards,
    Raffaele 